### PR TITLE
Integrate with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+
+services:
+  - docker
+
+language: cpp
+
+install: true
+
+script:
+-  docker run -ti --rm -v $(pwd):/marjoram studerl/marjoram_build /marjoram/ci/travis.sh
+
+
+before_install:
+  - docker pull studerl/marjoram_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,6 @@ else()
   message(FATAL_ERROR)
 endif()
 
-
-# Sanitizer settings for testrun_san target
-set(SANITIZE_UNDEFINED OFF)
-set(SANITIZE_ADDRESS OFF)
-set(SANITIZE_MEMORY OFF)
-
 add_library(marjoram INTERFACE)
 
 target_include_directories(marjoram INTERFACE include)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Marjoram
+
+[![Build Status](https://travis-ci.org/studer-l/marjoram.svg?branch=master)](https://travis-ci.org/studer-l/marjoram)
+
 Tiny header-only library for functional programming in C++.
 
 ## Requirements

--- a/ci/dockerfile
+++ b/ci/dockerfile
@@ -1,0 +1,5 @@
+FROM buildpack-deps:xenial-scm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+                      clang cmake libboost-dev make \
+ && rm -rf /var/lib/apt/lists*

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# script ran by travis inside docker container
+set -ex
+
+# Build with address and undefinedb behavior sanitizer
+BUILDDIR=/build
+mkdir -p $BUILDDIR
+cd $BUILDDIR
+cmake -DSANITIZE_ADDRESS=ON -DSANITIZE_UNDEFINED=ON /marjoram
+make testrun -j4

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,11 +12,4 @@ add_custom_target(testrun
 
 # tests with sanitizers
 find_package(Sanitizers)
-
-add_executable(marjoram_test_san ${test_SRC})
-target_link_libraries(marjoram_test_san gtest_main)
-add_sanitizers(marjoram_test_san)
-add_custom_target(testrun_san
-    COMMAND marjoram_test_san
-    DEPENDS marjoram_test_san
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+add_sanitizers(marjoram_test)


### PR DESCRIPTION
Builds and runs sanitized tests on travis inside docker image that has
sufficiently recent version of boost and clang.