### PR TITLE
ma::Maybe: Implement getOrElse with transfer of ownership

### DIFF
--- a/include/marjoram/maybe.hpp
+++ b/include/marjoram/maybe.hpp
@@ -300,9 +300,21 @@ template <typename A> class Maybe {
 
   /**
    * If this object contains a value, returns it. Otherwise returns `dflt`.
-   * @return reference to contained value.
+   * @return reference to contained value or argument.
    */
   const A& getOrElse(const A& dflt) const { return isJust() ? get() : dflt; }
+
+  /**
+   * If this object contains a value, returns it (along with ownership).
+   * Otherwise returns `dflt`. If `A` cannot be moved, it will be copied.
+   * @return The contained value or argument.
+   */
+  A getOrElse(A dflt) && {
+    if (isJust()) {
+      return std::move(get());
+    }
+    return dflt;
+  }
 
   /**
    * Return result of applying predicate to stored value if there is one, false

--- a/test/test_maybe.cxx
+++ b/test/test_maybe.cxx
@@ -355,5 +355,19 @@ TEST(Maybe, filter) {
 TEST(Maybe, filter_move) {
   ma::Maybe<std::unique_ptr<int>> uniqueFour(std::make_unique<int>(4));
   auto isEven = [](const std::unique_ptr<int>& i) { return *i % 2 == 0; };
-  ASSERT_TRUE(std::move(uniqueFour).filter(isEven).exists([](const auto& ptr) {return *ptr == 4;}));
+  ASSERT_TRUE(std::move(uniqueFour).filter(isEven).exists([](const auto& ptr) {
+    return *ptr == 4;
+  }));
+}
+
+TEST(Maybe, get_or_else_move) {
+  ma::Maybe<std::unique_ptr<int>> uniqueFour(std::make_unique<int>(4));
+  auto rlyFour = std::move(uniqueFour).getOrElse(std::make_unique<int>(5));
+  ASSERT_EQ(*rlyFour, 4);
+}
+
+TEST(Maybe, get_or_else_move_nothing) {
+  ma::Maybe<std::unique_ptr<int>> nada = ma::Nothing;
+  auto five = std::move(nada).getOrElse(std::make_unique<int>(5));
+  ASSERT_EQ(*five, 5);
 }


### PR DESCRIPTION
Suppose you have a `ma::Maybe<std::unique_ptr<T>`, it was not possible to
transfer ownership of the contained `unique_ptr` with `getOrElse`. This is now
possible with an rvalue ref overload on `getOrElse`.