### PR TITLE
extend Maybe::toRight and Maybe::toLeft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ doc/latex
 *.swp
 .clangd
 compile_commands.json
+.cache

--- a/include/marjoram/maybe.hpp
+++ b/include/marjoram/maybe.hpp
@@ -253,23 +253,45 @@ template <typename A> class Maybe {
   /**
    * @return ma::Either containing either the stored value or the argument.
    */
-  template <class Left> Either<Left, A> toRight(const Left& left) const {
+  template <class Left> Either<Left, A> toRight(Left&& left) const& {
     using Either = Either<Left, A>;
     if (isJust()) {
       return Either(ma::Right, get());
     }
-    return Either(ma::Left, left);
+    return Either(ma::Left, std::forward<Left>(left));
   }
 
   /**
    * @return ma::Either containing either the stored value or the argument.
    */
-  template <class Right> Either<A, Right> toLeft(const Right& right) const {
+  template <class Left> Either<Left, A> toRight(Left&& left) && {
+    using Either = Either<Left, A>;
+    if (isJust()) {
+      return Either(ma::Right, std::move(get()));
+    }
+    return Either(ma::Left, std::forward<Left>(left));
+  }
+
+  /**
+   * @return ma::Either containing either the stored value or the argument.
+   */
+  template <class Right> Either<A, Right> toLeft(Right&& right) const& {
     using Either = Either<A, Right>;
     if (isJust()) {
       return Either(ma::Left, get());
     }
-    return Either(ma::Right, right);
+    return Either(ma::Right, std::forward<Right>(right));
+  }
+
+  /**
+   * @return ma::Either containing either the stored value or the argument.
+   */
+  template <class Right> Either<A, Right> toLeft(Right&& right) && {
+    using Either = Either<A, Right>;
+    if (isJust()) {
+      return Either(ma::Left, std::move(get()));
+    }
+    return Either(ma::Right, std::forward<Right>(right));
   }
 
   /**

--- a/test/test_maybe.cxx
+++ b/test/test_maybe.cxx
@@ -261,6 +261,56 @@ TEST(Maybe, toLeft_Failcase) {
   ASSERT_EQ(E.asRight(), std::string("wat"));
 }
 
+TEST(Maybe, toRight_move) {
+  auto nc = Just(NoCopy_t());
+  auto e = std::move(nc).toRight(std::string("oops"));
+  ASSERT_FALSE(nc.get().hasBrains);
+}
+
+TEST(Maybe, toRight_move_default_unused) {
+  auto mbstring = Just(std::string("hi"));
+  auto e = std::move(mbstring).toRight(NoCopy_t{});
+}
+
+TEST(Maybe, toRight_move_default) {
+  auto mbstring = ma::Maybe<std::string>{};
+
+  // copy
+  auto e = mbstring.toRight(NoCopy_t{});
+  ASSERT_TRUE(e.isLeft());
+  ASSERT_TRUE(e.asLeft().hasBrains);
+
+  // move
+  e = std::move(mbstring).toRight(NoCopy_t{});
+  ASSERT_TRUE(e.isLeft());
+  ASSERT_TRUE(e.asLeft().hasBrains);
+}
+
+TEST(Maybe, toLeft_move) {
+  auto nc = Just(NoCopy_t());
+  auto e = std::move(nc).toLeft(std::string("oops"));
+  ASSERT_FALSE(nc.get().hasBrains);
+}
+
+TEST(Maybe, toLeft_move_default_unused) {
+  auto mbstring = Just(std::string("hi"));
+  auto e = std::move(mbstring).toLeft(NoCopy_t{});
+}
+
+TEST(Maybe, toLeft_move_default) {
+  auto mbstring = ma::Maybe<std::string>{};
+
+  // copy
+  auto e = mbstring.toLeft(NoCopy_t{});
+  ASSERT_TRUE(e.isRight());
+  ASSERT_TRUE(e.asRight().hasBrains);
+
+  // move
+  e = std::move(mbstring).toLeft(NoCopy_t{});
+  ASSERT_TRUE(e.isRight());
+  ASSERT_TRUE(e.asRight().hasBrains);
+}
+
 TEST(Maybe, ToVector) {
   Maybe<float> MbF = ma::Just(42.0f);
   std::vector<float> v(MbF.begin(), MbF.end());


### PR DESCRIPTION
- generalize to default values that cannot be copied
- allow the value stored in the `Maybe` to be move into the resulting `Either`