### PR TITLE
Mark both Maybe and Either as nodiscard

### DIFF
--- a/include/marjoram/either.hpp
+++ b/include/marjoram/either.hpp
@@ -3,6 +3,7 @@
 #include "eitherImpl.hpp"
 #include "maybe.hpp"
 #include "nothing.hpp"
+#include "utils.h"
 #include <algorithm>
 #include <type_traits>
 
@@ -58,7 +59,7 @@ template <typename A> class Maybe;
  * value, similarly for B and right.
  */
 template <typename A, typename B>
-class Either : private detail::EitherImpl<A, B> {
+class MARJORAM_NODISCARD Either : private detail::EitherImpl<A, B> {
  private:
   using impl = detail::EitherImpl<A, B>;
   static_assert(std::is_same<std::decay_t<A>, A>::value,

--- a/include/marjoram/maybe.hpp
+++ b/include/marjoram/maybe.hpp
@@ -2,6 +2,7 @@
 
 #include "either.hpp"
 #include "nothing.hpp"
+#include "utils.h"
 #include <boost/optional/optional.hpp>
 #include <type_traits>
 #include <utility>
@@ -61,7 +62,7 @@ template <typename A, typename B> class Either;
  * Type requirements:
  *  A must be a value type
  */
-template <typename A> class Maybe {
+template <typename A> class MARJORAM_NODISCARD Maybe {
   static_assert(std::is_same<std::decay_t<A>, A>::value,
                 "Maybe<A>: A must be a value type.");
 

--- a/include/marjoram/utils.h
+++ b/include/marjoram/utils.h
@@ -1,0 +1,6 @@
+#pragma once
+#if not defined(MARJORAM_ALLOW_DISCARD) && __has_cpp_attribute(nodiscard)
+#define MARJORAM_NODISCARD [[nodiscard]]
+#else
+#define MARJORAM_NODISCARD
+#endif

--- a/include/marjoram/utils.h
+++ b/include/marjoram/utils.h
@@ -1,5 +1,6 @@
 #pragma once
-#if not defined(MARJORAM_ALLOW_DISCARD) && __has_cpp_attribute(nodiscard)
+#if not defined(MARJORAM_ALLOW_DISCARD) && defined(__has_cpp_attribute) && \
+    __has_cpp_attribute(nodiscard)
 #define MARJORAM_NODISCARD [[nodiscard]]
 #else
 #define MARJORAM_NODISCARD

--- a/test/test_maybe.cxx
+++ b/test/test_maybe.cxx
@@ -428,3 +428,8 @@ TEST(Maybe, equal_nothing) {
   ASSERT_EQ(ma::Maybe<int>(), ma::Nothing);
   ASSERT_EQ(ma::Maybe<float>(), ma::Maybe<float>());
 }
+
+TEST(Maybe, warns_on_discard) {
+  auto f = []() { return ma::Maybe<int> { 5 }; };
+  f();  // this line must produce a compiler warning
+}


### PR DESCRIPTION
Adds the `nodiscard` attribute to both `Maybe` and `Either`, similar to Rust's `must_use`.

Disable this feature by defining `MARJORAM_ALLOW_DISCARD`.