### PR TITLE
ma::Maybe: getOrElseWith function for lazy creation in case of isNothing

### DIFF
--- a/include/marjoram/maybe.hpp
+++ b/include/marjoram/maybe.hpp
@@ -340,6 +340,17 @@ template <typename A> class MARJORAM_NODISCARD Maybe {
   }
 
   /**
+   * If this object contains a value, returns it. Otherwise returns `factory()`.
+   * @return The contained value or value returned by calling `factory()`
+   */
+  template <typename F> A getOrElseWith(F factory) && {
+    if (isJust()) {
+      return std::move(get());
+    }
+    return factory();
+  }
+
+  /**
    * Return result of applying predicate to stored value if there is one, false
    * otherwise.
    *

--- a/test/test_maybe.cxx
+++ b/test/test_maybe.cxx
@@ -423,6 +423,22 @@ TEST(Maybe, get_or_else_move_nothing) {
   ASSERT_EQ(*five, 5);
 }
 
+TEST(Maybe, get_or_else_with_lambda) {
+  ma::Maybe<std::unique_ptr<int>> nada = ma::Nothing;
+  auto five = std::move(nada).getOrElseWith([](){return std::make_unique<int>(5);});
+  ASSERT_EQ(*five, 5);
+}
+
+std::unique_ptr<int> unique_one(){
+  return std::make_unique<int>(1);
+}
+
+TEST(Maybe, get_or_else_with_function) {
+  ma::Maybe<std::unique_ptr<int>> nada = ma::Nothing;
+  auto one = std::move(nada).getOrElseWith(unique_one);
+  ASSERT_EQ(*one, 1);
+}
+
 TEST(Maybe, equal_nothing) {
   ASSERT_EQ(ma::Nothing, ma::Maybe<int>());
   ASSERT_EQ(ma::Maybe<int>(), ma::Nothing);


### PR DESCRIPTION
Sometimes when using getOrElse the default value might be heavy to construct, but it constructed on every call of no matter if the optional contains a value or not. The getOrElseWith provides a way to construct the default value by providing a factory functor.